### PR TITLE
Load the JWT plugin on load

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -32,6 +32,7 @@
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="JWTAuth">
         <param name="android-package" value="edu.berkeley.eecs.emission.cordova.jwtauth.JWTAuthPlugin"/>
+        <param name="onload" value="true"/>
       </feature>
     </config-file>
 
@@ -53,6 +54,7 @@
     <config-file target="config.xml" parent="/*">
       <feature name="JWTAuth">
         <param name="ios-package" value="BEMJWTAuth" />
+        <param name="onload" value="true"/>
       </feature>
     </config-file>
 


### PR DESCRIPTION
This is a pre-emptive fix for
https://github.com/e-mission/cordova-jwt-auth/issues/8

We have a real fix that doesn't delete the consent. But just in case the
consent *is* deleted locally, this ensures that syncs continue so that it is
restored.