### PR TITLE
Set the clientID and clientSecret when the completion handler is init…

### DIFF
--- a/src/ios/AuthCompletionHandler.m
+++ b/src/ios/AuthCompletionHandler.m
@@ -41,6 +41,11 @@ static AuthCompletionHandler *sharedInstance;
     if (sharedInstance == nil) {
         NSLog(@"creating new AuthCompletionHandler sharedInstance");
         sharedInstance = [AuthCompletionHandler new];
+        // Handle google+ sign on
+        sharedInstance.clientId = [[ConnectionSettings sharedInstance] getGoogleiOSClientID];
+        sharedInstance.clientSecret = [[ConnectionSettings sharedInstance] getGoogleiOSClientSecret];
+        [LocalNotificationManager addNotification:[NSString stringWithFormat:@"Finished setting clientId = %@ and clientSecret = %@", sharedInstance.clientId, sharedInstance.clientSecret]];
+
     }
     return sharedInstance;
 }
@@ -159,6 +164,9 @@ static AuthCompletionHandler *sharedInstance;
     if (self.currAuth == NULL) {
         [LocalNotificationManager addNotification:[NSString stringWithFormat:
                                                    @"currAuth = null, reading the current value from the keychain"]];
+        [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                                   @"current clientId = %@ and clientSecret = %@", self.clientId, self.clientSecret]];
+        
 
         GTMOAuth2Authentication* tempAuth = [GTMOAuth2ViewControllerTouch authForGoogleFromKeychainForName:kKeychainItemName
                                                                                                   clientID:self.clientId

--- a/src/ios/BEMJWTAuth.m
+++ b/src/ios/BEMJWTAuth.m
@@ -1,6 +1,6 @@
 #import "BEMJWTAuth.h"
 #import "AuthCompletionHandler.h"
-#import "BEMConnectionSettings.h"
+#import "LocalNotificationManager.h"
 
 @interface BEMJWTAuth () <AuthCompletionDelegate>
 @property (nonatomic, retain) CDVInvokedUrlCommand* command;
@@ -10,9 +10,8 @@
 
 - (void)pluginInitialize
 {
-    // Handle google+ sign on
-    [AuthCompletionHandler sharedInstance].clientId = [[ConnectionSettings sharedInstance] getGoogleiOSClientID];
-    [AuthCompletionHandler sharedInstance].clientSecret = [[ConnectionSettings sharedInstance] getGoogleiOSClientSecret];
+    [LocalNotificationManager addNotification:@"BEMJWTAuth:pluginInitialize singleton -> initialize completion handler"];
+    [LocalNotificationManager addNotification:[NSString stringWithFormat:@"Auth handler is %@", [AuthCompletionHandler sharedInstance]]];
 }
 
 - (void)getUserEmail:(CDVInvokedUrlCommand*)command


### PR DESCRIPTION
…ialized

+ add more logging to make the auth workflow more clear
+ remove unnecessary includes

This is a partial fix for #8 