### PR TITLE
Change the call to the connection settings to get the clientID

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="edu.berkeley.eecs.emission.cordova.auth"
-        version="1.2.0">
+        version="1.2.1">
   
   <name>JWTAuth</name>
   <description>Get the user email and associated JWT tokens from both native

--- a/src/ios/GoogleSigninAuth.m
+++ b/src/ios/GoogleSigninAuth.m
@@ -41,7 +41,7 @@ NSString* const BEMJWTAuthComplete = @"BEMJWTAuthComplete";
         sharedInstance = [GoogleSigninAuth new];
 
         GIDSignIn* signIn = [GIDSignIn sharedInstance];
-        signIn.clientID = [[ConnectionSettings sharedInstance] getClientID];
+        signIn.clientID = [[ConnectionSettings sharedInstance] authValueForKey:@"clientID"];
         // client secret is no longer required for this client
         // signIn.serverClientID = [[ConnectionSettings sharedInstance] getGoogleiOSClientSecret];
         signIn.delegate = sharedInstance;


### PR DESCRIPTION
This deals with the outcome of
https://github.com/e-mission/cordova-connection-settings/pull/14

Switch to using an auth-specific key instead of using hardcoded values.
Bump up the plugin version.