### PR TITLE
Bump up the podspec to avoid compilation errors

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -97,7 +97,7 @@
     <framework src="SystemConfiguration.framework"/>
     <framework src="Security.framework"/>
     <framework src="GoogleSignIn" type="podspec" spec="~> 4.0.0"/>
-    <framework src="AppAuth" type="podspec" spec="~> 0.90.0"/>
+    <framework src="AppAuth" type="podspec" spec="~> 0.91.0"/>
     <framework src="JWT" type="podspec" spec="~> 2.2.0"/>
 
     <header-file src="src/ios/BEMJWTAuth.h"/>


### PR DESCRIPTION
Issue https://github.com/openid/AppAuth-iOS/issues/146
Fix https://github.com/openid/AppAuth-iOS/pull/158
Release in https://github.com/openid/AppAuth-iOS/releases/tag/0.91.0

> Fixes several "availability" warnings and errors. Corrects deployment targets.