### PR TITLE
Rename comments and strings from dummy dev to prompted auth

### DIFF
--- a/src/android/AuthTokenCreationFactory.java
+++ b/src/android/AuthTokenCreationFactory.java
@@ -20,7 +20,7 @@ public class AuthTokenCreationFactory {
         } else if ("prompted-auth".equals(authMethod)) {
             return new PromptedAuth(ctxt);
         } else {
-            // Return dummy dev sign-in handler by default so that:
+            // Return prompted auth sign-in handler by default so that:
             // - we know that this will never return null
             // - dev users can start working without any configuration stuff
             return new PromptedAuth(ctxt);

--- a/src/android/PromptedAuth.java
+++ b/src/android/PromptedAuth.java
@@ -16,7 +16,7 @@ import org.apache.cordova.CordovaPlugin;
 /**
  * Created by shankari on 8/21/17.
  *
- * Implementation of the dummy dev auth code to allow developers to login with multiple user IDs
+ * Implementation of the prompted auth code to allow developers to login with multiple user IDs
  * for testing + to provide another exemplar of logging in properly :)
  */
 
@@ -25,7 +25,7 @@ class PromptedAuth implements AuthTokenCreator {
     private AuthPendingResult mAuthPending;
     private Context mCtxt;
 
-    private static final String TAG = "DummyDevAuth";
+    private static final String TAG = "PromptedAuth";
     private static final String METHOD_PARAM_KEY = "method";
     private static final String TOKEN_PARAM_KEY = "token";
     private static final String EXPECTED_HOST = "auth";
@@ -62,14 +62,14 @@ class PromptedAuth implements AuthTokenCreator {
 
     @Override
     public AuthPendingResult getServerToken() {
-        // For the dummy-dev case, the token is the user email
+        // For the prompted-auth case, the token is the user email
         return readStoredUserAuthEntry(mCtxt);
     }
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         Log.d(mCtxt, TAG, "onActivityResult(" + requestCode + "," + resultCode + "," + data.getDataString());
-        Log.i(mCtxt, TAG, "onActivityResult unused in `dummy-dev, ignoring call...");
+        Log.i(mCtxt, TAG, "onActivityResult unused in `prompted-auth, ignoring call...");
     }
 
     @Override
@@ -122,7 +122,7 @@ class PromptedAuth implements AuthTokenCreator {
     private String getPrompt() {
         String configPrompt = ConnectionSettings.getAuthValue(mCtxt, "prompt");
         if (configPrompt == null) {
-            // return dummy-dev prompt by default to continue supporting config-less
+            // return prompted-auth prompt by default to continue supporting config-less
             // development
             configPrompt = "Dummy dev mode: Enter email";
         }

--- a/src/ios/AuthTokenCreationFactory.m
+++ b/src/ios/AuthTokenCreationFactory.m
@@ -24,7 +24,7 @@
     } else if ([settings.authMethod  isEqual: @"prompted-auth"]) {
         return [PromptedAuth sharedInstance];
     } else {
-        // Return dummy dev sign-in handler by default so that:
+        // Return prompted auth sign-in handler by default so that:
         // - we know that this will never return null
         // - dev users can start working without any configuration stuff
         return [PromptedAuth sharedInstance];

--- a/src/ios/OpenIDAuth.h
+++ b/src/ios/OpenIDAuth.h
@@ -1,5 +1,5 @@
 //
-//  DummyDevAuth.h
+//  OpenIDAuth.h
 //  emission
 //
 //  Created by Andrew Tan

--- a/src/ios/PromptedAuth.h
+++ b/src/ios/PromptedAuth.h
@@ -1,5 +1,5 @@
 //
-//  DummyDevAuth.h
+//  PromptedAuth.h
 //  emission
 //
 //  Created by Kalyanaraman Shankari on 8/20/17.

--- a/src/ios/PromptedAuth.m
+++ b/src/ios/PromptedAuth.m
@@ -1,5 +1,5 @@
 //
-//  DummyDevAuth.m
+//  PromptedAuth.m
 //  emission
 //
 //  Created by Kalyanaraman Shankari on 8/20/17.
@@ -52,7 +52,7 @@ static PromptedAuth *sharedInstance;
         NSURLQueryItem* tokenParam = queryItems[1];
         
         if (([methodParam.name isEqualToString:METHOD_PARAM_KEY]) && ([methodParam.value isEqualToString:EXPECTED_METHOD])) {
-            // For the dummy-dev method name
+            // For the prompted-auth method name
             if ([tokenParam.name isEqualToString:TOKEN_PARAM_KEY]) {
                 NSString* userName = tokenParam.value;
                 [LocalNotificationManager addNotification:
@@ -92,7 +92,7 @@ static PromptedAuth *sharedInstance;
 
 - (void) getJWT:(AuthResultCallback) authResultCallback
 {
-    // For the dummy-dev method, token = username
+    // For the prompted-auth method, token = username
     authResultCallback([self getStoredUserAuthEntry], NULL);
 }
 


### PR DESCRIPTION
Only current use of dummy dev is in the fallback if a prompt is not specified
for prompted auth. This allows development to proceed without any
configuration, but removes all other references to obsolete code.

```
$ grep -r DummyDev src/
$ grep -r dummy-dev src/
$ grep -r Dummy src/
src//ios/PromptedAuth.m:        configPrompt = @"Dummy dev mode: Enter email";
src//android/PromptedAuth.java:            configPrompt = "Dummy dev mode: Enter email";
$ grep -r dummy src/
$
```