### PR TITLE
Ensure that we ignore URL launches if the auth method is not yet configured

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="edu.berkeley.eecs.emission.cordova.auth"
-        version="1.4.0">
+        version="1.4.1">
   
   <name>JWTAuth</name>
   <description>Get the user email and associated JWT tokens from both native


### PR DESCRIPTION
This makes the iOS code consistent with android and fixes #33