### PR TITLE
Add an option to save programatically save local tokens

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="edu.berkeley.eecs.emission.cordova.auth"
-        version="1.5.0">
+        version="1.6.0">
   
   <name>JWTAuth</name>
   <description>Get the user email and associated JWT tokens from both native

--- a/src/android/JWTAuthPlugin.java
+++ b/src/android/JWTAuthPlugin.java
@@ -69,6 +69,17 @@ public class JWTAuthPlugin extends CordovaPlugin {
                 }
             });
             return true;
+        } else if (action.equals("setPromptedAuthToken")) {
+            if (tokenCreator.getClass() != PromptedAuth.class) {
+                callbackContext.error("Attempting to set programmatic token conflicts"
+                        + "with configured auth method");
+            }
+            String email = data.getString(0);
+            Log.d(cordova.getActivity(),TAG,
+                    "Force setting the prompted auth token = "+email);
+            UserProfile.getInstance(cordova.getActivity()).setUserEmail(email);
+            callbackContext.success(email);
+            return true;
         } else {
             return false;
         }

--- a/src/android/PromptedAuth.java
+++ b/src/android/PromptedAuth.java
@@ -43,7 +43,7 @@ class PromptedAuth implements AuthTokenCreator {
         this.mAuthPending = new AuthPendingResult();
         this.mPlugin = plugin;
 
-        final String devJSScript = "window.cordova.plugins.BEMJWTAuth.launchDevAuth('"+getPrompt()+"')";
+        final String devJSScript = "window.cordova.plugins.BEMJWTAuth.launchPromptedAuth('"+getPrompt()+"')";
         Log.d(mCtxt, TAG, "About to execute script: "+devJSScript);
         final CordovaPlugin finalPlugin = plugin;
         plugin.cordova.getActivity().runOnUiThread(new Runnable() {

--- a/src/ios/PromptedAuth.h
+++ b/src/ios/PromptedAuth.h
@@ -11,4 +11,5 @@
 
 @interface PromptedAuth : NSObject <AuthTokenCreator>
 + (PromptedAuth*) sharedInstance;
++ (void) setStoredUserAuthEntry: (NSString*)token;
 @end

--- a/src/ios/PromptedAuth.m
+++ b/src/ios/PromptedAuth.m
@@ -55,10 +55,10 @@ static PromptedAuth *sharedInstance;
             // For the prompted-auth method name
             if ([tokenParam.name isEqualToString:TOKEN_PARAM_KEY]) {
                 NSString* userName = tokenParam.value;
+                [PromptedAuth setStoredUserAuthEntry:userName];
                 [LocalNotificationManager addNotification:
                  [NSString stringWithFormat:@"in handleNotification, received userName %@",
                   userName]];
-                [[NSUserDefaults standardUserDefaults] setObject:userName forKey:STORAGE_KEY];
                 self.mResultCallback(userName, NULL);
             } else {
                 [LocalNotificationManager addNotification:
@@ -85,6 +85,11 @@ static PromptedAuth *sharedInstance;
     return [[NSUserDefaults standardUserDefaults] objectForKey:STORAGE_KEY];
 }
 
++ (void) setStoredUserAuthEntry: (NSString*)token
+{
+    [[NSUserDefaults standardUserDefaults] setObject:token forKey:STORAGE_KEY];
+}
+
 - (void) getEmail:(AuthResultCallback) authResultCallback
 {
     authResultCallback([self getStoredUserAuthEntry], NULL);
@@ -104,7 +109,7 @@ static PromptedAuth *sharedInstance;
 - (void) uiSignIn:(AuthResultCallback)authResultCallback withPlugin:(CDVPlugin *)plugin
 {
     self.mResultCallback = authResultCallback;
-    NSString* devJSScript = [NSString stringWithFormat:@"window.cordova.plugins.BEMJWTAuth.launchDevAuth('%@')", self.prompt];
+    NSString* devJSScript = [NSString stringWithFormat:@"window.cordova.plugins.BEMJWTAuth.launchPromptedAuth('%@')", self.prompt];
     [LocalNotificationManager addNotification:@"About to execute script"];
     [LocalNotificationManager addNotification:devJSScript];
     [plugin.commandDelegate evalJs:devJSScript];

--- a/www/jwtauth.js
+++ b/www/jwtauth.js
@@ -28,7 +28,20 @@ var JWTAuth = {
         });
     },
 
-    launchDevAuth: function(promptMsg) {
+    /*
+     * Although we generally support auth through callbacks, this is special
+     * because we may want to call it from the client to programatically create
+     * a string or token and we don't want to jump through in app browser hoops
+     * to do so.
+     */
+
+    setPromptedAuthToken(email) {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "JWTAuth", "setPromptedAuthToken", [email]);
+        });
+    },
+
+    launchPromptedAuth: function(promptMsg) {
         var email = window.prompt(promptMsg, '');
         // window.alert('email = '+email);
         var callbackURL = 'emission://auth?method=prompted-auth&token='+email;


### PR DESCRIPTION
Sometimes, we don't want to prompt the user for a token but generate one in the
javascript and store it. The generating is easy enough, but the storage is
currently hard since it involves sending a custom URL notification to the plugin.

Instead of fiddling around with weird inapp browser schemes to pass through the URL,
let us handle this directly in the plugin since we wrote it ourselves.

+ bump up version number