### PR TITLE
Upgrade the version of GoogleSignIn to remove references to UIWebView

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="edu.berkeley.eecs.emission.cordova.auth"
-        version="1.6.1">
+        version="1.6.2-alpha1">
   
   <name>JWTAuth</name>
   <description>Get the user email and associated JWT tokens from both native
@@ -92,9 +92,9 @@
 
     <framework src="SystemConfiguration.framework"/>
     <framework src="Security.framework"/>
-    <framework src="GoogleSignIn" type="podspec" spec="~> 4.0.0"/>
-    <framework src="AppAuth" type="podspec" spec="~> 0.91.0"/>
-    <framework src="JWT" type="podspec" spec="~> 2.2.0"/>
+    <framework src="GoogleSignIn" type="podspec" spec="~> 5.0.0"/>
+    <framework src="AppAuth" type="podspec" spec="~> 1.2"/>
+    <framework src="JWT" type="podspec" spec="~> 3.0.0-beta.12"/>
 
     <header-file src="src/ios/BEMJWTAuth.h"/>
     <header-file src="src/ios/GoogleSigninAuth.h"/>

--- a/src/ios/OpenIDAuth.m
+++ b/src/ios/OpenIDAuth.m
@@ -21,7 +21,7 @@
  serialize to disk.
  */
 @property(nonatomic, nullable) OIDAuthState *_authState;
-@property (nonatomic, strong, nullable) id<OIDAuthorizationFlowSession> currentAuthorizationFlow;
+@property (nonatomic, strong, nullable) id<OIDExternalUserAgentSession> currentAuthorizationFlow;
 @property (atomic, retain) CDVPlugin* mPlugin;
 
 /*! @brief The OIDC issuer from which the configuration will be discovered.
@@ -94,7 +94,7 @@ static OpenIDAuth *sharedInstance;
     // For compatibility with iOS 10 and earlier
     NSURL* url = [notification object];
     if ([url.scheme isEqualToString:@"emission.auth"]) {
-        if([self.currentAuthorizationFlow resumeAuthorizationFlowWithURL:url]) {
+        if([self.currentAuthorizationFlow resumeExternalUserAgentFlowWithURL:url]) {
             self.currentAuthorizationFlow = nil;
         } else {
             [LocalNotificationManager addNotification:[NSString stringWithFormat:@"[iOS Auth] Resuming authorization flow failed with redirect URL: %@", url]];


### PR DESCRIPTION
This also required an upgrade to AppAuth, and changes to the GoogleAuth and
OpenIDAuth code. This compiles, and will let me publish to the AppStore without
any UIWebView references, so I am going to check it in. However, I have not yet
tested the GoogleSigninAuth code, so this is tagged as an alpha release.