### PR TITLE
Add a null check for "data" in the callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-em-jwt-auth",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Several wrappers for authentication methods",
   "license": "BSD-3-Clause",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-jwt-auth"
-        version="1.6.3">
+        version="1.6.4">
   
   <name>JWTAuth</name>
   <description>Get the user email and associated JWT tokens from both native

--- a/src/android/PromptedAuth.java
+++ b/src/android/PromptedAuth.java
@@ -71,7 +71,7 @@ class PromptedAuth implements AuthTokenCreator {
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        Log.d(mCtxt, TAG, "onActivityResult(" + requestCode + "," + resultCode + "," + data.getDataString());
+        Log.d(mCtxt, TAG, "onActivityResult(" + requestCode + "," + resultCode);
         Log.i(mCtxt, TAG, "onActivityResult unused in `prompted-auth, ignoring call...");
     }
 


### PR DESCRIPTION
Since the app settings screen does not have an output
Similar to https://github.com/e-mission/e-mission-data-collection/pull/192/commits/a726584663a2b315eea02183b4d4294710a3cb16