### PR TITLE
:bug: Remove call to obsolete function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-em-opcodeauth",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Wrapper for the single authentication method (token based auth)",
   "license": "BSD-3-Clause",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-opcodeauth"
-        version="1.7.0">
+        version="1.7.1">
   
   <name>OPCodeAuth</name>
   <description>Get the authentication token (aka opcode) associaed with a user.</description>

--- a/src/ios/BEMOPCode.m
+++ b/src/ios/BEMOPCode.m
@@ -35,7 +35,6 @@
             }
         }];
     }
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationLaunchedWithUrl:) name:CDVPluginHandleOpenURLNotification object:nil];
 }
 
 - (void)getOPCode:(CDVInvokedUrlCommand*)command


### PR DESCRIPTION
In https://github.com/e-mission/cordova-jwt-auth/commit/0ef812ce7a5252785621657b61a22aff078abb30 we removed the `applicationLaunchedWithUrl` callback

We need to remove the invocation of the callback as well I am not sure how we were able to test with this; I suspect I made the one-line fix directly in the platform directory and forgot to port it back