### PR TITLE
:fire: simplify auth plugin further

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-opcodeauth"
-        version="1.7.1">
+        version="1.7.2">
   
   <name>OPCodeAuth</name>
   <description>Get the authentication token (aka opcode) associaed with a user.</description>

--- a/src/android/AuthPendingResult.java
+++ b/src/android/AuthPendingResult.java
@@ -43,7 +43,7 @@ public class AuthPendingResult extends PendingResult<AuthResult> {
                     }
                 }
             } catch (InterruptedException e) {
-                mAuthResult = new AuthResult(new Status(CommonStatusCodes.INTERRUPTED), null, null);
+                mAuthResult = new AuthResult(new Status(CommonStatusCodes.INTERRUPTED), null);
             }
             return mAuthResult;
         }
@@ -65,7 +65,7 @@ public class AuthPendingResult extends PendingResult<AuthResult> {
                     }
                 }
             } catch (InterruptedException e) {
-                mAuthResult = new AuthResult(new Status(CommonStatusCodes.INTERRUPTED), null, null);
+                mAuthResult = new AuthResult(new Status(CommonStatusCodes.INTERRUPTED), null);
             }
         }
         return mAuthResult;
@@ -74,7 +74,7 @@ public class AuthPendingResult extends PendingResult<AuthResult> {
     @Override
     public void cancel() {
         synchronized(syncToken) {
-            mAuthResult = new AuthResult(new Status(CommonStatusCodes.CANCELED), null, null);
+            mAuthResult = new AuthResult(new Status(CommonStatusCodes.CANCELED), null);
             mCancelled = true;
             syncToken.notify();
             if (mResultCallback != null) {
@@ -116,7 +116,7 @@ public class AuthPendingResult extends PendingResult<AuthResult> {
                         synchronized (syncToken) {
                             if (mAuthResult == null) {
                                 AuthResult timeoutResult = new AuthResult(
-                                        new com.google.android.gms.common.api.Status(CommonStatusCodes.TIMEOUT), null, null);
+                                        new com.google.android.gms.common.api.Status(CommonStatusCodes.TIMEOUT), null);
                                 mResultCallback.onResult(timeoutResult);
                                 mResultCallback = null;
                             } else {
@@ -126,7 +126,7 @@ public class AuthPendingResult extends PendingResult<AuthResult> {
                     } catch (InterruptedException e) {
                         synchronized (syncToken) {
                             AuthResult timeoutResult = new AuthResult(
-                                    new com.google.android.gms.common.api.Status(CommonStatusCodes.INTERRUPTED), null, null);
+                                    new com.google.android.gms.common.api.Status(CommonStatusCodes.INTERRUPTED), null);
                             mResultCallback.onResult(timeoutResult);
                             mResultCallback = null;
                         }

--- a/src/android/AuthResult.java
+++ b/src/android/AuthResult.java
@@ -11,13 +11,11 @@ import com.google.android.gms.common.api.Status;
 
 public class AuthResult implements Result {
     private Status status;
-    private String email;
-    private String token;
+    private String opcode;
 
-    public AuthResult(Status istatus, String iemail, String itoken) {
+    public AuthResult(Status istatus, String iopcode) {
         status = istatus;
-        email = iemail;
-        token = itoken;
+        opcode = iopcode;
     }
 
     @Override
@@ -25,11 +23,7 @@ public class AuthResult implements Result {
         return status;
     }
 
-    public String getEmail() {
-        return email;
-    }
-
-    public String getToken() {
-        return token;
+    public String getOPCode() {
+        return opcode;
     }
 }

--- a/src/android/AuthTokenCreator.java
+++ b/src/android/AuthTokenCreator.java
@@ -12,6 +12,5 @@ import org.json.JSONException;
 
 public interface AuthTokenCreator {
     public AuthPendingResult getOPCode();
-    public AuthPendingResult getServerToken();
     public void setOPCode(String token) throws JSONException;
 }

--- a/src/android/OPCodePlugin.java
+++ b/src/android/OPCodePlugin.java
@@ -29,7 +29,7 @@ public class OPCodePlugin extends CordovaPlugin {
                 @Override
                 public void onResult(@NonNull AuthResult authResult) {
                     if (authResult.getStatus().isSuccess()) {
-                        callbackContext.success(authResult.getEmail());
+                        callbackContext.success(authResult.getOPCode());
                     } else {
                         callbackContext.error(authResult.getStatus().getStatusCode() + " : "+
                                 authResult.getStatus().getStatusMessage());

--- a/src/android/PromptedAuth.java
+++ b/src/android/PromptedAuth.java
@@ -46,12 +46,6 @@ class PromptedAuth implements AuthTokenCreator {
         return readStoredUserAuthEntry(mCtxt);
     }
 
-    @Override
-    public AuthPendingResult getServerToken() {
-        // For the prompted-auth case, the token is the user email
-        return readStoredUserAuthEntry(mCtxt);
-    }
-
     private AuthPendingResult readStoredUserAuthEntry(Context ctxt) {
         AuthPendingResult authPending = new AuthPendingResult();
         AuthResult result = null;
@@ -64,11 +58,11 @@ class PromptedAuth implements AuthTokenCreator {
             }
             result = new AuthResult(
                 new Status(CommonStatusCodes.SUCCESS),
-                    token, token);
+                    token);
         } catch (JSONException e) {
             result = new AuthResult(
                     new Status(CommonStatusCodes.ERROR),
-                    e.getLocalizedMessage(), e.getLocalizedMessage());
+                    e.getLocalizedMessage());
         }
         authPending.setResult(result);
         return authPending;
@@ -76,8 +70,7 @@ class PromptedAuth implements AuthTokenCreator {
 
     @Override
     public void setOPCode(String opcode) throws JSONException {
-        // For the prompted-auth case, the token is the user email
-        writeStoredUserAuthEntry(mCtxt, opcode);
+        throw new JSONException("Storing opcodes through the plugin is no longer supported since it does not duplicate data");
     }
 
     private void writeStoredUserAuthEntry(Context ctxt, String opcode) throws JSONException {

--- a/src/ios/PromptedAuth.m
+++ b/src/ios/PromptedAuth.m
@@ -64,7 +64,7 @@ static PromptedAuth *sharedInstance;
 
 - (void) setOPCode:(NSString*) opcode
 {
-    [self setStoredUserAuthEntry:opcode];
+    [NSException raise:@"Storing opcodes through the plugin is no longer supported since it does not duplicate data"];
 }
 
 @end


### PR DESCRIPTION
- Remove all references to "email" since we don't actually store the email any more, only the opcode. We were duplicating the opcode as the email recently, might as well remove it to avoid confusion
- remove the methods to return the server tokens, we currently use the opcode as the token directly
- raise errors if we try to set the opcode through the plugin since we are doing so directly from the javascript in the KVStore

This is part of the workaround for
https://github.com/e-mission/e-mission-docs/issues/930